### PR TITLE
feat: structured outputs (json_schema) for OpenAI — Level 3 enforcement

### DIFF
--- a/service/src/config/keyword_schema.js
+++ b/service/src/config/keyword_schema.js
@@ -1,3 +1,8 @@
+// OpenAI strict mode requires ALL declared properties to be in `required[]`.
+// Optional fields are expressed as nullable (type: ["<type>", "null"]) so the
+// model can emit null when a field does not apply to the current workflow,
+// while still satisfying the strict schema contract.
+// Gemini ignores the nullable widening and continues to work as before.
 export const KEYWORD_EXTRACTION_SCHEMA = {
   type: "object",
   properties: {
@@ -13,27 +18,28 @@ export const KEYWORD_EXTRACTION_SCHEMA = {
         "metadata_question_v1",
       ],
     },
+    is_followup: { type: "boolean" },
     asked_info: {
-      type: "array",
+      type: ["array", "null"],
       items: { type: "string", enum: ["granth", "anuyog", "author", "link"] },
     },
     keywords: {
-      type: "array",
+      type: ["array", "null"],
       items: { type: "string" },
     },
     filters: {
-      type: "object",
+      type: ["object", "null"],
       properties: {
-        granth: { type: "string" },
-        anuyog: { type: "string" },
-        contributor: { type: "string" },
-        content_type: { type: "array", items: { type: "string" } },
+        granth: { type: ["string", "null"] },
+        anuyog: { type: ["string", "null"] },
+        contributor: { type: ["string", "null"] },
+        content_type: { type: ["array", "null"], items: { type: "string" } },
       },
+      required: ["granth", "anuyog", "contributor", "content_type"],
       additionalProperties: false,
     },
-    is_followup: { type: "boolean" },
     followup_keywords: {
-      type: "array",
+      type: ["array", "null"],
       items: {
         type: "object",
         properties: {
@@ -48,11 +54,11 @@ export const KEYWORD_EXTRACTION_SCHEMA = {
       },
     },
     expand_chunk_ids: {
-      type: "array",
+      type: ["array", "null"],
       items: { type: "string" },
     },
     queries: {
-      type: "array",
+      type: ["array", "null"],
       items: {
         type: "object",
         properties: {
@@ -67,7 +73,7 @@ export const KEYWORD_EXTRACTION_SCHEMA = {
       },
     },
     main_query: {
-      type: "object",
+      type: ["object", "null"],
       properties: {
         keywords: {
           type: "array",
@@ -78,7 +84,7 @@ export const KEYWORD_EXTRACTION_SCHEMA = {
       additionalProperties: false,
     },
     sub_queries: {
-      type: "array",
+      type: ["array", "null"],
       items: {
         type: "object",
         properties: {
@@ -93,6 +99,18 @@ export const KEYWORD_EXTRACTION_SCHEMA = {
       },
     },
   },
-  required: ["language", "workflow", "is_followup"],
+  required: [
+    "language",
+    "workflow",
+    "is_followup",
+    "asked_info",
+    "keywords",
+    "filters",
+    "followup_keywords",
+    "expand_chunk_ids",
+    "queries",
+    "main_query",
+    "sub_queries",
+  ],
   additionalProperties: false,
 };

--- a/service/src/providers/openai.js
+++ b/service/src/providers/openai.js
@@ -25,8 +25,20 @@ export class OpenAIProvider extends LLMProvider {
     });
   }
 
-  async completeJson({ messages, temperature, maxTokens, requestId }) {
-    const responseFormat = this.jsonMode ? { type: "json_object" } : null;
+  async completeJson({ messages, temperature, maxTokens, requestId, responseJsonSchema }) {
+    let responseFormat = null;
+    if (this.jsonMode) {
+      responseFormat = responseJsonSchema
+        ? {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              strict: true,
+              schema: responseJsonSchema,
+            },
+          }
+        : { type: "json_object" };
+    }
     return this.#chatCompletion({
       messages,
       temperature,


### PR DESCRIPTION
## Summary

- **`openai.js`** — `completeJson()` now accepts `responseJsonSchema` and sends it to OpenAI as `response_format: { type: "json_schema", strict: true, schema: ... }`. Previously the schema was silently dropped and OpenAI only got `json_object` (valid JSON, any shape). Falls back to `json_object` when no schema is passed.
- **`keyword_schema.js`** — Made OpenAI strict-mode compatible: all properties added to `required[]`; optional fields typed as `["<type>", "null"]` so the model emits `null` when a field doesn't apply. `filters` sub-object updated the same way. `answer_schema.js` was already compatible — no change needed.
- **`answer_synthesis.js` / `keyword_extract.js`** — No changes; both already pass `responseJsonSchema` to `completeJson()`.
- **Gemini** — Unaffected; it already used `responseJsonSchema` correctly.

## Before / After

| | Before | After |
|---|---|---|
| OpenAI keyword extraction | Level 2 — valid JSON, any shape | Level 3 — schema enforced at token level |
| OpenAI answer synthesis | Level 2 — valid JSON, any shape | Level 3 — schema enforced at token level |
| Gemini (both) | Level 3 ✓ | Level 3 ✓ (unchanged) |

## Test plan

- [ ] Trigger a keyword extraction call via OpenAI and confirm the response payload always contains all required fields with correct types
- [ ] Trigger an answer synthesis call and confirm `answer` + `scoring` are always present and correctly typed
- [ ] Verify `null` is returned (not omitted) for unused optional keyword fields (e.g. `main_query` on a basic question)
- [ ] Confirm Gemini flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)