### PR TITLE
feat: persist actual LLM token usage per call into request_logs (closes #15)

### DIFF
--- a/service/src/feedback/feedback_routes.js
+++ b/service/src/feedback/feedback_routes.js
@@ -209,6 +209,35 @@ export function registerFeedbackRoutes(app, feedbackStore, { adminApiKey, reques
     return res.json(record);
   });
 
+  app.get("/v1/admin/cost-analysis", requireAdmin(adminApiKey), (req, res) => {
+    if (!requestLogStore) {
+      return res.status(503).json({ detail: "request_logs_not_enabled" });
+    }
+
+    const from = parseOptionalNumber(req.query.from);
+    const to = parseOptionalNumber(req.query.to);
+    const requestId = sanitizeQueryString(req.query.request_id);
+    const sessionId = sanitizeQueryString(req.query.session_id);
+    const userId = sanitizeQueryString(req.query.user_id);
+    const steps = req.query.step
+      ? (Array.isArray(req.query.step) ? req.query.step : [req.query.step]).map(String)
+      : null;
+    const limit = Math.min(Number(req.query.limit) || 50, 200);
+    const offset = Math.max(Number(req.query.offset) || 0, 0);
+
+    const result = requestLogStore.getCostAnalysis({
+      from,
+      to,
+      requestId,
+      sessionId,
+      userId,
+      steps,
+      limit,
+      offset,
+    });
+    return res.json(result);
+  });
+
   app.get("/v1/admin/feedback/:id", requireAdmin(adminApiKey), (req, res) => {
     if (!feedbackStore) {
       return res.status(503).json({ detail: "feedback_not_enabled" });

--- a/service/src/orchestrator/answer_synthesis.js
+++ b/service/src/orchestrator/answer_synthesis.js
@@ -18,6 +18,7 @@ export async function runAnswerSynthesis({
   modelId,
   responseFormat = "combined",
   fullCitations,
+  llmCallsCollector,
 }) {
   const guidelines = getWorkflowGuidelines(workflowName, { modelId, requestId });
   const useV2 = isPromptV2();
@@ -50,9 +51,9 @@ export async function runAnswerSynthesis({
     { modelId, requestId, responseFormat, fullCitations }
   );
   const responseJsonSchema = getAnswerSchema({ workflowName, responseFormat });
-  log.info("answer_synthesis_prompt_tokens", {
+  log.info("answer_synthesis_prompt_tokens_estimate", {
     requestId,
-    tokens: estimateTokens(prompt),
+    tokens_estimate: estimateTokens(prompt),
   });
 
   const messages = [
@@ -60,12 +61,14 @@ export async function runAnswerSynthesis({
     { role: "user", content: prompt },
   ];
 
-  const raw = await provider.completeJson({
+  const result = await provider.completeJson({
     messages,
     temperature: Number(process.env.LLM_TEMPERATURE || 0.75),
     requestId,
     responseJsonSchema,
   });
+
+  const raw = result.text;
 
   // Logged at info to correlate with downstream response parsing.
   // Avoid logging full answer to keep logs manageable.
@@ -74,9 +77,22 @@ export async function runAnswerSynthesis({
     length: raw?.length || 0,
     preview: String(raw || "").slice(0, 500),
   });
-  log.info("answer_synthesis_output_tokens", {
+  log.info("answer_synthesis_usage", {
     requestId,
-    tokens: estimateTokens(raw),
+    input_tokens: result.usage_normalized?.input_tokens,
+    output_tokens: result.usage_normalized?.output_tokens,
+    cached_input_tokens: result.usage_normalized?.cached_input_tokens,
+    thought_tokens: result.usage_normalized?.thought_tokens,
+  });
+
+  llmCallsCollector?.push({
+    step: "answer_synthesis",
+    provider: provider.name(),
+    model: modelId || null,
+    provider_response_id: result.provider_response_id,
+    model_version: result.model_version,
+    usage_raw: result.usage_raw,
+    usage_normalized: result.usage_normalized,
   });
 
   const parsed = await parseOrRepairJson({
@@ -85,6 +101,8 @@ export async function runAnswerSynthesis({
     requestId,
     responseJsonSchema,
     responseFormat,
+    modelId,
+    llmCallsCollector,
   });
   log.info("answer_synthesis_scoring", {
     requestId,
@@ -93,7 +111,7 @@ export async function runAnswerSynthesis({
   return parsed;
 }
 
-async function parseOrRepairJson({ raw, provider, requestId, responseJsonSchema, responseFormat }) {
+async function parseOrRepairJson({ raw, provider, requestId, responseJsonSchema, responseFormat, modelId, llmCallsCollector }) {
   try {
     return parseJsonStrict(raw);
   } catch (err) {
@@ -113,17 +131,34 @@ async function parseOrRepairJson({ raw, provider, requestId, responseJsonSchema,
   ];
 
   try {
-    const repairedRaw = await provider.completeJson({
+    const repairResult = await provider.completeJson({
       messages: repairMessages,
       temperature: 0,
       requestId,
       responseJsonSchema,
     });
 
+    const repairedRaw = repairResult.text;
+
     log.verbose("answer_synthesis_llm_repair_response", {
       requestId,
       length: repairedRaw?.length || 0,
       preview: String(repairedRaw || "").slice(0, 500),
+    });
+    log.info("answer_json_repair_usage", {
+      requestId,
+      input_tokens: repairResult.usage_normalized?.input_tokens,
+      output_tokens: repairResult.usage_normalized?.output_tokens,
+    });
+
+    llmCallsCollector?.push({
+      step: "answer_json_repair",
+      provider: provider.name(),
+      model: modelId || null,
+      provider_response_id: repairResult.provider_response_id,
+      model_version: repairResult.model_version,
+      usage_raw: repairResult.usage_raw,
+      usage_normalized: repairResult.usage_normalized,
     });
 
     try {

--- a/service/src/orchestrator/keyword_extract.js
+++ b/service/src/orchestrator/keyword_extract.js
@@ -11,6 +11,7 @@ export async function runKeywordExtraction({
   sessionContext,
   requestId,
   modelId,
+  llmCallsCollector,
 }) {
   const useV2 = isPromptV2();
   const history = formatConversationHistory(sessionContext?.conversationHistory, {
@@ -19,9 +20,9 @@ export async function runKeywordExtraction({
     compact: useV2,
   });
   const prompt = getKeywordPrompt(question, history, { modelId, requestId });
-  log.info("keyword_extract_prompt_tokens", {
+  log.info("keyword_extract_prompt_tokens_estimate", {
     requestId,
-    tokens: estimateTokens(prompt),
+    tokens_estimate: estimateTokens(prompt),
   });
 
   const messages = [
@@ -29,21 +30,35 @@ export async function runKeywordExtraction({
     { role: "user", content: prompt },
   ];
 
-  const raw = await provider.completeJson({
+  const result = await provider.completeJson({
     messages,
     temperature: 0,
     requestId,
     responseJsonSchema: KEYWORD_EXTRACTION_SCHEMA,
   });
 
+  const raw = result.text;
+
   log.verbose("keyword_extract_llm_response", {
     requestId,
     length: raw?.length || 0,
     response: String(raw || ""),
   });
-  log.info("keyword_extract_output_tokens", {
+  log.info("keyword_extract_usage", {
     requestId,
-    tokens: estimateTokens(raw),
+    input_tokens: result.usage_normalized?.input_tokens,
+    output_tokens: result.usage_normalized?.output_tokens,
+    cached_input_tokens: result.usage_normalized?.cached_input_tokens,
+  });
+
+  llmCallsCollector?.push({
+    step: "keyword_extract",
+    provider: provider.name(),
+    model: modelId || null,
+    provider_response_id: result.provider_response_id,
+    model_version: result.model_version,
+    usage_raw: result.usage_raw,
+    usage_normalized: result.usage_normalized,
   });
 
   let parsed;

--- a/service/src/orchestrator/keyword_fix.js
+++ b/service/src/orchestrator/keyword_fix.js
@@ -4,11 +4,11 @@ import { parseJsonStrict } from "../utils/json.js";
 import { estimateTokens } from "../utils/token.js";
 import { log } from "../utils/log.js";
 
-export async function runKeywordFix({ provider, question, step1Json, requestId, modelId }) {
+export async function runKeywordFix({ provider, question, step1Json, requestId, modelId, llmCallsCollector }) {
   const prompt = getKeywordFixPrompt(question, step1Json, { modelId, requestId });
-  log.info("keyword_fix_prompt_tokens", {
+  log.info("keyword_fix_prompt_tokens_estimate", {
     requestId,
-    tokens: estimateTokens(prompt),
+    tokens_estimate: estimateTokens(prompt),
   });
 
   const messages = [
@@ -16,16 +16,33 @@ export async function runKeywordFix({ provider, question, step1Json, requestId, 
     { role: "user", content: prompt },
   ];
 
-  const raw = await provider.completeJson({
+  const result = await provider.completeJson({
     messages,
     temperature: 0,
     requestId,
     responseJsonSchema: KEYWORD_EXTRACTION_SCHEMA,
   });
 
+  const raw = result.text;
+
   log.verbose("keyword_fix_llm_response", {
     requestId,
     length: raw?.length || 0,
+  });
+  log.info("keyword_fix_usage", {
+    requestId,
+    input_tokens: result.usage_normalized?.input_tokens,
+    output_tokens: result.usage_normalized?.output_tokens,
+  });
+
+  llmCallsCollector?.push({
+    step: "keyword_fix",
+    provider: provider.name(),
+    model: modelId || null,
+    provider_response_id: result.provider_response_id,
+    model_version: result.model_version,
+    usage_raw: result.usage_raw,
+    usage_normalized: result.usage_normalized,
   });
 
   const parsed = parseJsonStrict(raw);

--- a/service/src/orchestrator/keyword_fix_retry.js
+++ b/service/src/orchestrator/keyword_fix_retry.js
@@ -9,6 +9,7 @@ export async function retryWorkflowOnEmptyChunks({
   provider,
   externalApi,
   modelId,
+  llmCallsCollector,
   runWorkflowFn = runWorkflow,
   runKeywordFixFn = runKeywordFix,
   prepareKeywordResult = (result) => result,
@@ -20,6 +21,7 @@ export async function retryWorkflowOnEmptyChunks({
     requestId,
     provider,
     modelId,
+    llmCallsCollector,
   });
   const initialChunks = Array.isArray(first.chunks) ? first.chunks : [];
   if (initialChunks.length > 0) {
@@ -43,6 +45,7 @@ export async function retryWorkflowOnEmptyChunks({
     step1Json: initialKeywordResult,
     requestId,
     modelId,
+    llmCallsCollector,
   });
   const preparedFixed = prepareKeywordResult(fixedKeywordResult);
   const second = await runWorkflowFn({
@@ -51,6 +54,7 @@ export async function retryWorkflowOnEmptyChunks({
     requestId,
     provider,
     modelId,
+    llmCallsCollector,
   });
   return {
     ...second,

--- a/service/src/orchestrator/workflow_router.js
+++ b/service/src/orchestrator/workflow_router.js
@@ -40,6 +40,7 @@ export async function runWorkflow({ externalApi, keywordResult, requestId, provi
       requestId,
       allowFailure: workflowName !== "basic_question_v1",
       provider,
+      modelId,
       llmCallsCollector,
     });
 
@@ -64,7 +65,7 @@ export async function runWorkflow({ externalApi, keywordResult, requestId, provi
   return { workflowName, chunks, toolCallsUsed: toolBudget.used };
 }
 
-async function resolveFilters({ externalApi, filters, language, requestId, allowFailure, provider, llmCallsCollector }) {
+async function resolveFilters({ externalApi, filters, language, requestId, allowFailure, provider, modelId, llmCallsCollector }) {
   if (!filters || typeof filters !== "object") return {};
   const hasExplicitFilter = Boolean(
     filters.granth ||
@@ -116,6 +117,7 @@ async function resolveFilters({ externalApi, filters, language, requestId, allow
     const mapped = await mapFiltersWithLlm({
       provider,
       requestId,
+      modelId,
       original: {
         granth: filters.granth || "",
         anuyog: filters.anuyog || "",
@@ -201,7 +203,7 @@ function resolveMatchWithFlag(value, options) {
   return { value, matched: false };
 }
 
-async function mapFiltersWithLlm({ provider, requestId, original, options, llmCallsCollector }) {
+async function mapFiltersWithLlm({ provider, requestId, modelId, original, options, llmCallsCollector }) {
   const system = "You map filter values to the closest valid option. Output JSON only.";
   const user = [
     "Map each provided filter to the best matching option from the lists.",
@@ -238,7 +240,7 @@ async function mapFiltersWithLlm({ provider, requestId, original, options, llmCa
   llmCallsCollector?.push({
     step: "filter_map",
     provider: provider.name(),
-    model: null,
+    model: modelId || null,
     provider_response_id: result.provider_response_id,
     model_version: result.model_version,
     usage_raw: result.usage_raw,

--- a/service/src/orchestrator/workflow_router.js
+++ b/service/src/orchestrator/workflow_router.js
@@ -21,7 +21,7 @@ export class ToolBudget {
   }
 }
 
-export async function runWorkflow({ externalApi, keywordResult, requestId, provider = null, modelId = null }) {
+export async function runWorkflow({ externalApi, keywordResult, requestId, provider = null, modelId = null, llmCallsCollector }) {
   const workflowName = keywordResult.workflow || "basic_question_v1";
   const runner = workflowRegistry[workflowName];
   if (!runner) {
@@ -40,6 +40,7 @@ export async function runWorkflow({ externalApi, keywordResult, requestId, provi
       requestId,
       allowFailure: workflowName !== "basic_question_v1",
       provider,
+      llmCallsCollector,
     });
 
   const params = {
@@ -63,7 +64,7 @@ export async function runWorkflow({ externalApi, keywordResult, requestId, provi
   return { workflowName, chunks, toolCallsUsed: toolBudget.used };
 }
 
-async function resolveFilters({ externalApi, filters, language, requestId, allowFailure, provider }) {
+async function resolveFilters({ externalApi, filters, language, requestId, allowFailure, provider, llmCallsCollector }) {
   if (!filters || typeof filters !== "object") return {};
   const hasExplicitFilter = Boolean(
     filters.granth ||
@@ -121,6 +122,7 @@ async function resolveFilters({ externalApi, filters, language, requestId, allow
         contributor: filters.contributor || "",
       },
       options: merged,
+      llmCallsCollector,
     });
     resolved = {
       ...resolved,
@@ -199,7 +201,7 @@ function resolveMatchWithFlag(value, options) {
   return { value, matched: false };
 }
 
-async function mapFiltersWithLlm({ provider, requestId, original, options }) {
+async function mapFiltersWithLlm({ provider, requestId, original, options, llmCallsCollector }) {
   const system = "You map filter values to the closest valid option. Output JSON only.";
   const user = [
     "Map each provided filter to the best matching option from the lists.",
@@ -223,7 +225,7 @@ async function mapFiltersWithLlm({ provider, requestId, original, options }) {
     additionalProperties: false,
   };
 
-  const raw = await provider.completeJson({
+  const result = await provider.completeJson({
     messages: [
       { role: "system", content: system },
       { role: "user", content: user },
@@ -233,8 +235,18 @@ async function mapFiltersWithLlm({ provider, requestId, original, options }) {
     responseJsonSchema: schema,
   });
 
+  llmCallsCollector?.push({
+    step: "filter_map",
+    provider: provider.name(),
+    model: null,
+    provider_response_id: result.provider_response_id,
+    model_version: result.model_version,
+    usage_raw: result.usage_raw,
+    usage_normalized: result.usage_normalized,
+  });
+
   try {
-    return JSON.parse(raw);
+    return JSON.parse(result.text);
   } catch (err) {
     log.warn("filters_llm_map_parse_failed", { requestId, error: err?.message || String(err) });
     return { granth: "", anuyog: "", contributor: "" };

--- a/service/src/providers/gemini.js
+++ b/service/src/providers/gemini.js
@@ -76,7 +76,20 @@ export class GeminiProvider extends LLMProvider {
         if (!text) {
           throw new Error("Gemini response missing text");
         }
-        return String(text).trim();
+        const usage = response?.usageMetadata || {};
+        return {
+          text: String(text).trim(),
+          usage_raw: usage,
+          usage_normalized: {
+            input_tokens: usage.promptTokenCount ?? 0,
+            output_tokens: usage.candidatesTokenCount ?? 0,
+            total_tokens: usage.totalTokenCount ?? 0,
+            cached_input_tokens: usage.cachedContentTokenCount ?? 0,
+            thought_tokens: usage.thoughtsTokenCount != null ? usage.thoughtsTokenCount : null,
+          },
+          provider_response_id: response?.responseId ?? null,
+          model_version: response?.modelVersion ?? null,
+        };
       } finally {
         clearTimeout(timeout);
       }

--- a/service/src/providers/openai.js
+++ b/service/src/providers/openai.js
@@ -112,7 +112,20 @@ export class OpenAIProvider extends LLMProvider {
         log.warn("openai_empty_response", { requestId, response: summarize(json) });
         throw new Error("OpenAI response missing content");
       }
-      return content.trim();
+      const usage = json.usage || {};
+      return {
+        text: content.trim(),
+        usage_raw: usage,
+        usage_normalized: {
+          input_tokens: usage.prompt_tokens ?? 0,
+          output_tokens: usage.completion_tokens ?? 0,
+          total_tokens: usage.total_tokens ?? 0,
+          cached_input_tokens: usage.prompt_tokens_details?.cached_tokens ?? 0,
+          thought_tokens: null,
+        },
+        provider_response_id: json.id ?? null,
+        model_version: json.model ?? null,
+      };
     } finally {
       clearTimeout(timeout);
     }

--- a/service/src/request_logs/request_log_store.js
+++ b/service/src/request_logs/request_log_store.js
@@ -201,6 +201,82 @@ export class RequestLogStore {
     return row ? deserializeDetail(row) : null;
   }
 
+  getCostAnalysis({ from, to, requestId, sessionId, userId, steps, limit = 50, offset = 0 } = {}) {
+    const where = [];
+    const params = [];
+    const hasSessionsTable = this.#hasSessionsTable();
+
+    if (Number.isFinite(from)) { where.push("rl.created_at >= ?"); params.push(Number(from)); }
+    if (Number.isFinite(to)) { where.push("rl.created_at <= ?"); params.push(Number(to)); }
+    if (requestId) { where.push("rl.request_id = ?"); params.push(String(requestId)); }
+    if (sessionId) { where.push("rl.session_id = ?"); params.push(String(sessionId)); }
+    if (userId) {
+      if (!hasSessionsTable) return { summary: emptySummary(), by_day: [], requests: [], total: 0 };
+      where.push("s.user_id = ?"); params.push(String(userId));
+    }
+
+    const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+    const joinSql = hasSessionsTable ? "LEFT JOIN sessions s ON s.session_id = rl.session_id" : "";
+    const userIdSelect = hasSessionsTable ? "s.user_id AS user_id," : "NULL AS user_id,";
+
+    const safeLimit = Math.max(0, Number(limit) || 0);
+    const safeOffset = Math.max(0, Number(offset) || 0);
+
+    const rows = this.db.prepare(`
+      SELECT rl.request_id, rl.session_id, ${userIdSelect} rl.created_at, rl.details_json
+      FROM request_logs rl ${joinSql} ${whereSql}
+      ORDER BY rl.created_at DESC LIMIT ? OFFSET ?
+    `).all(...params, safeLimit, safeOffset);
+
+    const total = this.db.prepare(`
+      SELECT COUNT(*) AS total FROM request_logs rl ${joinSql} ${whereSql}
+    `).get(...params).total;
+
+    const summary = emptySummary();
+    const byDayMap = new Map();
+    const requests = [];
+
+    for (const row of rows) {
+      const details = tryParseJson(row.details_json);
+      let llmCalls = Array.isArray(details?.llm_calls) ? details.llm_calls : [];
+      if (steps && steps.length) {
+        llmCalls = llmCalls.filter((c) => steps.includes(c.step));
+      }
+      const rowSummary = emptySummary();
+      for (const call of llmCalls) {
+        const u = call.usage_normalized || {};
+        const it = u.input_tokens || 0;
+        const ot = u.output_tokens || 0;
+        const tt = u.total_tokens || 0;
+        summary.input_tokens += it;
+        summary.output_tokens += ot;
+        summary.total_tokens += tt;
+        rowSummary.input_tokens += it;
+        rowSummary.output_tokens += ot;
+        rowSummary.total_tokens += tt;
+
+        const day = new Date(row.created_at).toISOString().slice(0, 10);
+        const key = `${day}:${call.step}`;
+        if (!byDayMap.has(key)) byDayMap.set(key, { date: day, step: call.step, input_tokens: 0, output_tokens: 0, total_tokens: 0 });
+        const entry = byDayMap.get(key);
+        entry.input_tokens += it;
+        entry.output_tokens += ot;
+        entry.total_tokens += tt;
+      }
+      summary.request_count += 1;
+      requests.push({
+        request_id: row.request_id,
+        session_id: row.session_id,
+        user_id: row.user_id ?? null,
+        created_at: row.created_at,
+        llm_calls: llmCalls,
+        llm_usage_summary: rowSummary,
+      });
+    }
+
+    return { summary, by_day: [...byDayMap.values()].sort((a, b) => a.date.localeCompare(b.date)), requests, total };
+  }
+
   clear() {
     const result = this.clearStmt.run();
     log.info("request_log_store_cleared", {
@@ -251,4 +327,8 @@ function tryParseJson(value) {
   } catch {
     return null;
   }
+}
+
+function emptySummary() {
+  return { input_tokens: 0, output_tokens: 0, total_tokens: 0, request_count: 0 };
 }

--- a/service/src/request_logs/request_log_store.js
+++ b/service/src/request_logs/request_log_store.js
@@ -222,25 +222,24 @@ export class RequestLogStore {
     const safeLimit = Math.max(0, Number(limit) || 0);
     const safeOffset = Math.max(0, Number(offset) || 0);
 
-    const rows = this.db.prepare(`
+    // Fetch all rows matching SQL filters — step filtering happens in JS so the
+    // summary and total must be computed over the full filtered set, not just one page.
+    const allRows = this.db.prepare(`
       SELECT rl.request_id, rl.session_id, ${userIdSelect} rl.created_at, rl.details_json
       FROM request_logs rl ${joinSql} ${whereSql}
-      ORDER BY rl.created_at DESC LIMIT ? OFFSET ?
-    `).all(...params, safeLimit, safeOffset);
-
-    const total = this.db.prepare(`
-      SELECT COUNT(*) AS total FROM request_logs rl ${joinSql} ${whereSql}
-    `).get(...params).total;
+      ORDER BY rl.created_at DESC
+    `).all(...params);
 
     const summary = emptySummary();
     const byDayMap = new Map();
-    const requests = [];
+    const filtered = [];
 
-    for (const row of rows) {
+    for (const row of allRows) {
       const details = tryParseJson(row.details_json);
       let llmCalls = Array.isArray(details?.llm_calls) ? details.llm_calls : [];
       if (steps && steps.length) {
         llmCalls = llmCalls.filter((c) => steps.includes(c.step));
+        if (!llmCalls.length) continue; // exclude rows with no matching steps
       }
       const rowSummary = emptySummary();
       for (const call of llmCalls) {
@@ -264,7 +263,7 @@ export class RequestLogStore {
         entry.total_tokens += tt;
       }
       summary.request_count += 1;
-      requests.push({
+      filtered.push({
         request_id: row.request_id,
         session_id: row.session_id,
         user_id: row.user_id ?? null,
@@ -273,6 +272,9 @@ export class RequestLogStore {
         llm_usage_summary: rowSummary,
       });
     }
+
+    const total = filtered.length;
+    const requests = safeLimit > 0 ? filtered.slice(safeOffset, safeOffset + safeLimit) : filtered;
 
     return { summary, by_day: [...byDayMap.values()].sort((a, b) => a.date.localeCompare(b.date)), requests, total };
   }

--- a/service/src/request_logs/request_log_store.js
+++ b/service/src/request_logs/request_log_store.js
@@ -247,20 +247,24 @@ export class RequestLogStore {
         const it = u.input_tokens || 0;
         const ot = u.output_tokens || 0;
         const tt = u.total_tokens || 0;
+        const ct = u.cached_input_tokens || 0;
         summary.input_tokens += it;
         summary.output_tokens += ot;
         summary.total_tokens += tt;
+        summary.cached_input_tokens += ct;
         rowSummary.input_tokens += it;
         rowSummary.output_tokens += ot;
         rowSummary.total_tokens += tt;
+        rowSummary.cached_input_tokens += ct;
 
         const day = new Date(row.created_at).toISOString().slice(0, 10);
         const key = `${day}:${call.step}`;
-        if (!byDayMap.has(key)) byDayMap.set(key, { date: day, step: call.step, input_tokens: 0, output_tokens: 0, total_tokens: 0 });
+        if (!byDayMap.has(key)) byDayMap.set(key, { date: day, step: call.step, input_tokens: 0, output_tokens: 0, total_tokens: 0, cached_input_tokens: 0 });
         const entry = byDayMap.get(key);
         entry.input_tokens += it;
         entry.output_tokens += ot;
         entry.total_tokens += tt;
+        entry.cached_input_tokens += ct;
       }
       summary.request_count += 1;
       filtered.push({
@@ -332,5 +336,5 @@ function tryParseJson(value) {
 }
 
 function emptySummary() {
-  return { input_tokens: 0, output_tokens: 0, total_tokens: 0, request_count: 0 };
+  return { input_tokens: 0, output_tokens: 0, total_tokens: 0, cached_input_tokens: 0, request_count: 0 };
 }

--- a/service/src/server.js
+++ b/service/src/server.js
@@ -1033,9 +1033,10 @@ function writeRequestLog({ requestLogStore, requestId, requestStartedAt, request
       acc.input_tokens += u.input_tokens || 0;
       acc.output_tokens += u.output_tokens || 0;
       acc.total_tokens += u.total_tokens || 0;
+      acc.cached_input_tokens += u.cached_input_tokens || 0;
       return acc;
     },
-    { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
+    { input_tokens: 0, output_tokens: 0, total_tokens: 0, cached_input_tokens: 0 }
   );
   requestLogStore.upsert({
     requestId,

--- a/service/src/server.js
+++ b/service/src/server.js
@@ -970,13 +970,13 @@ export function createServer(options = {}) {
               },
               { role: "user", content: prompt },
             ];
-            const text = await provider.completeText({
+            const result = await provider.completeText({
               messages,
               temperature: 0.2,
               maxTokens: 2000,
               requestId,
             });
-            return String(text || "").trim();
+            return String(result?.text || "").trim();
           },
         });
 

--- a/service/src/server.js
+++ b/service/src/server.js
@@ -393,6 +393,7 @@ export function createServer(options = {}) {
       toolCallsUsed: null,
       contentType: null,
       answer: null,
+      llmCalls: [],
     };
     let requestLogWritten = false;
     let session = null;
@@ -606,6 +607,7 @@ export function createServer(options = {}) {
       },
       requestId,
       modelId: model.id,
+      llmCallsCollector: requestLogContext.llmCalls,
     });
     if (testMode && String(content || "").includes("FORCE_FOLLOWUP")) {
       keywordResult = {
@@ -676,6 +678,7 @@ export function createServer(options = {}) {
       provider,
       externalApi,
       modelId: model.id,
+      llmCallsCollector: requestLogContext.llmCalls,
       prepareKeywordResult: (result) => {
         const prepared = { ...result };
         if (normalizedUiFilters) {
@@ -819,6 +822,7 @@ export function createServer(options = {}) {
       modelId: model.id,
       responseFormat,
       fullCitations: fullCitationsParam,
+      llmCallsCollector: requestLogContext.llmCalls,
     });
 
     const answerStatusRaw = String(answerPayload?.answer_status || "").trim().toLowerCase();
@@ -1022,6 +1026,17 @@ function cleanSessionDbForTest({ enabled, dbPath }) {
 
 function writeRequestLog({ requestLogStore, requestId, requestStartedAt, requestLogContext, error }) {
   if (!requestLogStore || !requestId) return;
+  const llmCalls = Array.isArray(requestLogContext.llmCalls) ? requestLogContext.llmCalls : [];
+  const llmUsageSummary = llmCalls.reduce(
+    (acc, call) => {
+      const u = call.usage_normalized || {};
+      acc.input_tokens += u.input_tokens || 0;
+      acc.output_tokens += u.output_tokens || 0;
+      acc.total_tokens += u.total_tokens || 0;
+      return acc;
+    },
+    { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
+  );
   requestLogStore.upsert({
     requestId,
     sessionId: requestLogContext.sessionId ?? null,
@@ -1039,6 +1054,8 @@ function writeRequestLog({ requestLogStore, requestId, requestStartedAt, request
       tool_calls_used: requestLogContext.toolCallsUsed ?? null,
       content_type: requestLogContext.contentType ?? null,
       answer: requestLogContext.answer ?? null,
+      llm_calls: llmCalls.length ? llmCalls : undefined,
+      llm_usage_summary: llmCalls.length ? llmUsageSummary : undefined,
     },
   });
 }

--- a/service/src/testing/test_provider_factory.js
+++ b/service/src/testing/test_provider_factory.js
@@ -20,6 +20,22 @@ export function getTestProviderStats() {
   return stats;
 }
 
+function wrapTestResult(text) {
+  return {
+    text,
+    usage_raw: {},
+    usage_normalized: {
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+      cached_input_tokens: 0,
+      thought_tokens: null,
+    },
+    provider_response_id: "test-response-id",
+    model_version: "test-model-v1",
+  };
+}
+
 class TestProvider {
   constructor({ modelId, behavior }) {
     this.modelId = modelId;
@@ -36,17 +52,17 @@ class TestProvider {
     if (system.includes("keyword extractor")) {
       const userContent = String(messages?.[1]?.content || "");
       const forceFollowup = userContent.includes("FORCE_FOLLOWUP");
-      return JSON.stringify({
+      return wrapTestResult(JSON.stringify({
         language: "hi",
         script: "roman",
         workflow: "basic_question_v1",
         is_followup: forceFollowup,
         keywords: ["q"],
         filters: {},
-      });
+      }));
     }
     if (system.includes("you map filter values")) {
-      return JSON.stringify({ granth: "", anuyog: "", contributor: "" });
+      return wrapTestResult(JSON.stringify({ granth: "", anuyog: "", contributor: "" }));
     }
     if (this.behavior === "server_error") {
       const err = new Error("Service Unavailable");
@@ -64,41 +80,41 @@ class TestProvider {
       throw err;
     }
     if (this.behavior === "no_answer") {
-      return JSON.stringify({
+      return wrapTestResult(JSON.stringify({
         answer_status: "no_answer",
         answer: "किसी उपलब्ध संदर्भ में इसका स्पष्ट उत्तर नहीं मिला।",
         scoring: [],
-      });
+      }));
     }
     if (this.behavior === "no_answer_empty") {
-      return JSON.stringify({
+      return wrapTestResult(JSON.stringify({
         answer_status: "no_answer",
         answer: "",
         scoring: [],
-      });
+      }));
     }
     if (this.behavior === "no_answer_malformed") {
-      return JSON.stringify({
+      return wrapTestResult(JSON.stringify({
         answer_status: "no_answer",
         answer: "किसी उपलब्ध संदर्भ में इसका स्पष्ट उत्तर नहीं मिला।\n\n_If you want I can answer this in detail or I can also answer -_\n- q1",
         scoring: [{ chunk_id: "c1", score: 91 }],
-      });
+      }));
     }
     const userContent = String(messages?.[1]?.content || "");
     if (userContent.includes('"follow_up_questions"')) {
-      return JSON.stringify({ answer_status: "answered", answer: "test-answer", follow_up_questions: ["q1", "q2"], scoring: [] });
+      return wrapTestResult(JSON.stringify({ answer_status: "answered", answer: "test-answer", follow_up_questions: ["q1", "q2"], scoring: [] }));
     }
-    return JSON.stringify({
+    return wrapTestResult(JSON.stringify({
       answer_status: "answered",
       answer: "test-answer\n\n_If you want I can answer this in detail or I can also answer -_\n- q1\n- q2",
       scoring: [],
-    });
+    }));
   }
 
   async completeText({ messages }) {
     const system = String(messages?.[0]?.content || "").toLowerCase();
-    if (system.includes("summarizer")) return "test-summary";
-    return "test";
+    if (system.includes("summarizer")) return wrapTestResult("test-summary");
+    return wrapTestResult("test");
   }
 }
 

--- a/service/test/request_logs/request_log_store.test.js
+++ b/service/test/request_logs/request_log_store.test.js
@@ -117,3 +117,113 @@ test("RequestLogStore upserts and lists logs with filters", () => {
   store.close();
   sessionStore.close();
 });
+
+test("getCostAnalysis aggregates token usage including cached_input_tokens", () => {
+  const store = new RequestLogStore(makeTmpDb("cost-basic"));
+
+  store.upsert({
+    requestId: "r1",
+    createdAt: 1_000,
+    details: {
+      llm_calls: [
+        { step: "keyword_extract", usage_normalized: { input_tokens: 100, output_tokens: 20, total_tokens: 120, cached_input_tokens: 40 } },
+        { step: "answer_synthesis", usage_normalized: { input_tokens: 200, output_tokens: 50, total_tokens: 250, cached_input_tokens: 80 } },
+      ],
+      llm_usage_summary: { input_tokens: 300, output_tokens: 70, total_tokens: 370, cached_input_tokens: 120 },
+    },
+  });
+  store.upsert({
+    requestId: "r2",
+    createdAt: 2_000,
+    details: {
+      llm_calls: [
+        { step: "keyword_extract", usage_normalized: { input_tokens: 50, output_tokens: 10, total_tokens: 60, cached_input_tokens: 0 } },
+      ],
+      llm_usage_summary: { input_tokens: 50, output_tokens: 10, total_tokens: 60, cached_input_tokens: 0 },
+    },
+  });
+
+  const result = store.getCostAnalysis();
+
+  assert.equal(result.total, 2);
+  assert.equal(result.summary.request_count, 2);
+  assert.equal(result.summary.input_tokens, 350);
+  assert.equal(result.summary.output_tokens, 80);
+  assert.equal(result.summary.total_tokens, 430);
+  assert.equal(result.summary.cached_input_tokens, 120);
+
+  const r1 = result.requests.find((r) => r.request_id === "r1");
+  assert.equal(r1.llm_usage_summary.cached_input_tokens, 120);
+
+  store.close();
+});
+
+test("getCostAnalysis step filter excludes non-matching rows and scopes totals correctly", () => {
+  const store = new RequestLogStore(makeTmpDb("cost-step-filter"));
+
+  store.upsert({
+    requestId: "r1",
+    createdAt: 1_000,
+    details: {
+      llm_calls: [
+        { step: "keyword_extract", usage_normalized: { input_tokens: 100, output_tokens: 10, total_tokens: 110, cached_input_tokens: 5 } },
+        { step: "answer_synthesis", usage_normalized: { input_tokens: 200, output_tokens: 30, total_tokens: 230, cached_input_tokens: 10 } },
+      ],
+    },
+  });
+  store.upsert({
+    requestId: "r2",
+    createdAt: 2_000,
+    details: {
+      llm_calls: [
+        { step: "filter_map", usage_normalized: { input_tokens: 50, output_tokens: 5, total_tokens: 55, cached_input_tokens: 0 } },
+      ],
+    },
+  });
+
+  // filter to only answer_synthesis — r2 has no matching call, so it's excluded
+  const result = store.getCostAnalysis({ steps: ["answer_synthesis"] });
+
+  assert.equal(result.total, 1);
+  assert.equal(result.requests[0].request_id, "r1");
+  assert.equal(result.requests[0].llm_calls.length, 1);
+  assert.equal(result.requests[0].llm_calls[0].step, "answer_synthesis");
+  assert.equal(result.summary.input_tokens, 200);
+  assert.equal(result.summary.cached_input_tokens, 10);
+
+  store.close();
+});
+
+test("getCostAnalysis pagination: total reflects full count, requests is a page slice", () => {
+  const store = new RequestLogStore(makeTmpDb("cost-pagination"));
+
+  for (let i = 1; i <= 5; i++) {
+    store.upsert({
+      requestId: `r${i}`,
+      createdAt: i * 1_000,
+      details: {
+        llm_calls: [
+          { step: "keyword_extract", usage_normalized: { input_tokens: 10, output_tokens: 2, total_tokens: 12, cached_input_tokens: 1 } },
+        ],
+      },
+    });
+  }
+
+  const page1 = store.getCostAnalysis({ limit: 2, offset: 0 });
+  assert.equal(page1.total, 5);
+  assert.equal(page1.requests.length, 2);
+
+  const page2 = store.getCostAnalysis({ limit: 2, offset: 2 });
+  assert.equal(page2.total, 5);
+  assert.equal(page2.requests.length, 2);
+
+  const page3 = store.getCostAnalysis({ limit: 2, offset: 4 });
+  assert.equal(page3.total, 5);
+  assert.equal(page3.requests.length, 1);
+
+  // summary always covers all 5 rows regardless of page
+  assert.equal(page1.summary.request_count, 5);
+  assert.equal(page1.summary.cached_input_tokens, 5);
+
+  store.close();
+});


### PR DESCRIPTION
## Summary

- Each LLM call during a request (keyword extract, filter map, keyword fix, answer synthesis, JSON repair) now records actual provider-reported token counts — input, output, cached, and thought tokens
- Usage is stored in `details_json.llm_calls[]` and `details_json.llm_usage_summary` on the existing `request_logs` row — no schema migration required
- New admin endpoint `GET /v1/admin/cost-analysis` exposes this data with filtering by date range, user, session, request ID, and step type

## What changed

**Provider contract** (`gemini.js`, `openai.js`)
`completeJson()` and `completeText()` now return `{ text, usage_raw, usage_normalized, provider_response_id, model_version }` instead of a plain string. `usage_normalized` is a common shape across providers: `{ input_tokens, output_tokens, total_tokens, cached_input_tokens, thought_tokens }`.

**Orchestrators** (`keyword_extract.js`, `keyword_fix.js`, `answer_synthesis.js`, `workflow_router.js`, `keyword_fix_retry.js`)
Each accepts an optional `llmCallsCollector` array and pushes one entry per LLM call. The repair call in `answer_synthesis` is tracked separately as `answer_json_repair`.

**Request log context** (`server.js`)
`requestLogContext.llmCalls[]` is initialized at request start and passed to all orchestrators. `writeRequestLog` computes `llm_usage_summary` (sum across steps) and writes both fields into `details_json`.

**Store + admin route** (`request_log_store.js`, `feedback_routes.js`)
`getCostAnalysis()` filters rows and aggregates `llm_calls` in JS (no SQLite JSON extension required). `GET /v1/admin/cost-analysis` accepts `from`, `to`, `user_id`, `session_id`, `request_id`, `step` (multi-value).

**Test provider** (`test_provider_factory.js`)
All returns wrapped in `wrapTestResult()` to match the new provider contract. `answer_status` added to answer payloads (merged from main's no-answer feature).

## Reviewer notes

- History summarization (`scheduleHistorySummary`) runs in `setImmediate` after the request log is written — its usage is intentionally not tracked here, as documented in issue #15.
- `filter_map` and `keyword_fix` and `answer_json_repair` steps are conditional — not every request will have all five steps in `llm_calls`.
- The frontend Cost Analytics tab (separate PR in cataloguesearch) depends on this endpoint.

## Test plan

- [ ] Existing integration tests pass — provider contract change is fully covered by `wrapTestResult()` in test provider
- [ ] Send a chat message, check `request_logs.details_json` contains `llm_calls` array and `llm_usage_summary`
- [ ] Call `GET /v1/admin/cost-analysis` with various filter combinations
- [ ] Verify conditional steps (`filter_map`, `keyword_fix`, `answer_json_repair`) only appear when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)